### PR TITLE
PKG-5550: Add gguf-py and update to 0.10.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+channels:
+  - ai-staging
+
+# destination upon merge
+upload_channels:
+  - ai-staging

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,14 @@
 {% set name = "gguf" %}
-{% set version = "0.9.1" %}
+{% set version = "0.0.3609" %}
+
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/gguf-{{ version }}.tar.gz
-  sha256: f5e70987e15b19c545f6a9f7533b4033fb306330eb1f3c5c95fd28b14c3fd33b
+  url: https://github.com/ggerganov/llama.cpp/archive/b{{ version.split(".")[-1] }}.tar.gz
+  sha256: 9545e6cf7052927208538c19ffc97b939876714e4b756542a2c45afb8fd7e581
 
 build:
   entry_points:
@@ -16,7 +17,7 @@ build:
     - gguf-set-metadata = scripts:gguf_set_metadata_entrypoint
     - gguf-new-metadata = scripts:gguf_new_metadata_entrypoint
   skip: True # [py<38]
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script: cd gguf-py && {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
@@ -28,6 +29,7 @@ requirements:
     - python
     - numpy >=1.17
     - tqdm >=4.27
+    - pyyaml >=5.1
     - sentencepiece >=0.2.0 # This dependency is missing in the upstream pyproject.toml file: https://github.com/ggerganov/llama.cpp/blob/master/gguf-py/pyproject.toml
                             # PR: https://github.com/ggerganov/llama.cpp/pull/9107
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "gguf" %}
-{% set version = "0.6.0" %}
+{% set version = "0.9.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,34 +7,41 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/gguf-{{ version }}.tar.gz
-  sha256: b2e22eaba2a106c1ad148186a14ad9f29c429351686fe9d7ce16df39a0607e65
+  sha256: f5e70987e15b19c545f6a9f7533b4033fb306330eb1f3c5c95fd28b14c3fd33b
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
-  number: 0
   entry_points:
-    - gguf-convert-endian = "scripts:gguf_convert_endian_entrypoint"
-    - gguf-dump = "scripts:gguf_dump_entrypoint"
-    - gguf-set-metadata = "scripts:gguf_set_metadata_entrypoint"
+    - gguf-convert-endian = scripts:gguf_convert_endian_entrypoint
+    - gguf-dump = scripts:gguf_dump_entrypoint
+    - gguf-set-metadata = scripts:gguf_set_metadata_entrypoint
+    - gguf-new-metadata = scripts:gguf_new_metadata_entrypoint
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
 
 requirements:
   host:
     - python >=3.8
+    - poetry-core >=1.0.0
     - pip
-    - poetry-core
   run:
     - python >=3.8
     - numpy >=1.17
+    - tqdm >=4.27
+    - sentencepiece >=0.2.0
 
 test:
   imports:
     - gguf
   commands:
     - pip check
+    - gguf-convert-endian --help
+    - gguf-dump --help
+    - gguf-set-metadata --help
+    - gguf-new-metadata --help
   requires:
     - pip
-
+  
 about:
   home: https://ggml.ai
   summary: Read and write ML models in GGUF for GGML
@@ -44,3 +51,4 @@ about:
 extra:
   recipe-maintainers:
     - sodre
+    - jnoller

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  dev_url: https://github.com/ggerganov/llama.cpp
+  dev_url: https://github.com/ggerganov/llama.cpp/tree/master/gguf-py
   doc_url: https://github.com/ggerganov/llama.cpp/tree/master/gguf-py
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - poetry-core >=1.0.0
     - pip
   run:
-    - python >=3.8
+    - python
     - numpy >=1.17
     - tqdm >=4.27
     - sentencepiece >=0.2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
     - gguf-dump = scripts:gguf_dump_entrypoint
     - gguf-set-metadata = scripts:gguf_set_metadata_entrypoint
     - gguf-new-metadata = scripts:gguf_new_metadata_entrypoint
-  noarch: python
+  skip: True # [py<38]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ build:
 
 requirements:
   host:
-    - python >=3.8
+    - python
     - poetry-core >=1.0.0
     - pip
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "gguf" %}
-{% set version = "0.0.3609" %}
+{% set version = "0.10.0" %}
 
 
 package:
@@ -7,8 +7,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/ggerganov/llama.cpp/archive/b{{ version.split(".")[-1] }}.tar.gz
-  sha256: 9545e6cf7052927208538c19ffc97b939876714e4b756542a2c45afb8fd7e581
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/gguf-{{ version }}.tar.gz
+  sha256: 52a30ef26328b419ffc47d9269fc580c238edf1c8a19b5ea143c323e04a038c1
 
 build:
   entry_points:
@@ -17,7 +17,7 @@ build:
     - gguf-set-metadata = scripts:gguf_set_metadata_entrypoint
     - gguf-new-metadata = scripts:gguf_new_metadata_entrypoint
   skip: True # [py<38]
-  script: cd gguf-py && {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
@@ -30,7 +30,7 @@ requirements:
     - numpy >=1.17
     - tqdm >=4.27
     - pyyaml >=5.1
-    - sentencepiece >=0.2.0 # This dependency is missing in the upstream pyproject.toml file: https://github.com/ggerganov/llama.cpp/blob/master/gguf-py/pyproject.toml
+    - sentencepiece >=0.1.96,<0.2.0 # This dependency is missing in the upstream pyproject.toml file: https://github.com/ggerganov/llama.cpp/blob/master/gguf-py/pyproject.toml
                             # PR: https://github.com/ggerganov/llama.cpp/pull/9107
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,8 @@ requirements:
     - python
     - numpy >=1.17
     - tqdm >=4.27
-    - sentencepiece >=0.2.0
+    - sentencepiece >=0.2.0 # This dependency is missing in the upstream pyproject.toml file: https://github.com/ggerganov/llama.cpp/blob/master/gguf-py/pyproject.toml
+                            # PR: https://github.com/ggerganov/llama.cpp/pull/9107
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,6 @@ test:
     - gguf-new-metadata --help
   requires:
     - pip
-  
 about:
   home: https://ggml.ai
   summary: Read and write ML models in GGUF for GGML

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,8 +45,13 @@ test:
 about:
   home: https://ggml.ai
   summary: Read and write ML models in GGUF for GGML
+  description: |
+    Read and write ML models in GGUF for GGML
   license: MIT
+  license_family: MIT
   license_file: LICENSE
+  dev_url: https://github.com/ggerganov/llama.cpp
+  doc_url: https://github.com/ggerganov/llama.cpp/tree/master/gguf-py
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
gguf 0.10.0

**Destination channel:** ai-staging

### Links

- [PKG-5550](https://anaconda.atlassian.net/browse/PKG-5550) 
- [Upstream repository](https://github.com/ggerganov/llama.cpp/tree/master)
- [Upstream package](https://pypi.org/project/gguf/)
- [Upstream changelog/diff](https://pypi.org/project/gguf/#history)

### Explanation of changes:
- Aligns gguf-py with current upstream 0.10.0
- Fixes missing dependency
- Includes fixes from original PR review


[PKG-5550]: https://anaconda.atlassian.net/browse/PKG-5550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ